### PR TITLE
library only compiles when the zig compiler versions match

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,24 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+const zig_version = std.SemanticVersion{
+    .major = 0,
+    .minor = 13,
+    .patch = 0,
+};
+
+comptime {
+    // Compare versions while allowing different pre/patch metadata.
+    const zig_version_eq = zig_version.major == builtin.zig_version.major and
+        zig_version.minor == builtin.zig_version.minor and
+        zig_version.patch == builtin.zig_version.patch;
+    if (!zig_version_eq) {
+        @compileError(std.fmt.comptimePrint(
+            "unsupported zig version: expected {}, found {}",
+            .{ zig_version, builtin.zig_version },
+        ));
+    }
+}
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});


### PR DESCRIPTION
Hi!
This will prevent compiling on unsupported zig compiler versions
