### PR TITLE
fix: 修复几个编译期和运行时的 bug

### DIFF
--- a/src/core/pool.zig
+++ b/src/core/pool.zig
@@ -92,7 +92,7 @@ pub fn Pool(comptime T: type) type {
 
         /// Is this full?
         pub fn full(self: *const Self) bool {
-            return self.dirty.count() == self.list.len;
+            return self.dirty.count() == self.items.len;
         }
 
         /// Returns the number of clean (or available) slots.

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -207,7 +207,10 @@ pub fn Tardy(comptime selected_aio_type: AsyncType) type {
                             .pooling = options.pooling,
                             .size_tasks_initial = options.size_tasks_initial,
                             .size_aio_reap_max = options.size_aio_reap_max,
-                        }) catch return;
+                        }) catch |e| {
+                            log.err("failed to spawn runtime {d}: {t}", .{ current_id, e });
+                            return;
+                        };
                         defer thread_rt.deinit();
 
                         _ = count.fetchAdd(1, .acquire);

--- a/src/runtime/lib.zig
+++ b/src/runtime/lib.zig
@@ -5,7 +5,7 @@ const Async = @import("../aio/lib.zig").Async;
 const PoolKind = @import("../core/pool.zig").PoolKind;
 const Queue = @import("../core/queue.zig").Queue;
 const Frame = @import("../frame/lib.zig").Frame;
-const Timespec = @import("../lib.zig").Timespec;
+
 const Scheduler = @import("./scheduler.zig").Scheduler;
 const Storage = @import("storage.zig").Storage;
 const Task = @import("task.zig").Task;

--- a/src/runtime/storage.zig
+++ b/src/runtime/storage.zig
@@ -14,7 +14,7 @@ pub const Storage = struct {
         };
     }
 
-    pub fn deinit(self: Storage) void {
+    pub fn deinit(self: *Storage) void {
         self.arena.deinit();
     }
 


### PR DESCRIPTION
- pool.zig: full() 里 self.list 写错了，应该是 self.items
- runtime/lib.zig: 删掉不存在的 Timespec 导入，编译会报错
- storage.zig: deinit 改成接收 *Storage 指针，别用值拷贝
- lib.zig: 线程 spawn 失败时打日志，之前直接 catch return 静默吞掉错误会导致其他线程死等